### PR TITLE
remoção de NAs da base da ANEEL

### DIFF
--- a/R/epe4md_prepara_base.R
+++ b/R/epe4md_prepara_base.R
@@ -44,7 +44,12 @@ epe4md_prepara_base <- function(base_aneel,
     janitor::clean_names()
 
   base_mmgd <- base_mmgd %>%
-    drop_na(sig_agente, cod_municipio_ibge)
+    drop_na(sig_agente, cod_municipio_ibge, sig_modalidade_empreendimento,
+            sig_tipo_consumidor, sig_tipo_geracao, dth_atualiza_cadastral_empreend,
+            dsc_porte, dsc_sub_grupo_tarifario, dsc_classe_consumo, sig_uf,
+            mda_potencia_instalada_kw,
+            qtd_uc_recebe_credito,
+            dsc_fonte_geracao)
 
   base_mmgd <- base_mmgd %>%
     mutate(fonte_resumo = case_when(

--- a/R/epe4md_proj_geracao.R
+++ b/R/epe4md_proj_geracao.R
@@ -1,7 +1,7 @@
 #' Estima a geração de eletricidade a partir da projeção de potência
 #'
 #' @param proj_mensal dataframe. Resultado da função
-#' [epe4md::epe4md_proj_mensal].&&&
+#' [epe4md::epe4md_proj_mensal].
 #' @param ano_base numeric. Ano base da projeção. Define o ano em que a função
 #' irá buscar a base de dados. Último ano completo realizado.
 #' @param dir_dados_premissas Diretório onde se encontram as premissas.

--- a/R/epe4md_proj_geracao.R
+++ b/R/epe4md_proj_geracao.R
@@ -1,7 +1,7 @@
 #' Estima a geração de eletricidade a partir da projeção de potência
 #'
 #' @param proj_mensal dataframe. Resultado da função
-#' [epe4md::epe4md_proj_mensal].
+#' [epe4md::epe4md_proj_mensal].&&&
 #' @param ano_base numeric. Ano base da projeção. Define o ano em que a função
 #' irá buscar a base de dados. Último ano completo realizado.
 #' @param dir_dados_premissas Diretório onde se encontram as premissas.


### PR DESCRIPTION
Para evitar erros na sequência do código, são removidos os NAs. Representam 0,2% das observações.